### PR TITLE
goalTimeNrmを微変更

### DIFF
--- a/src/common/RaceDB.py
+++ b/src/common/RaceDB.py
@@ -1,3 +1,4 @@
+from http.client import MULTI_STATUS
 import numpy as np
 import os
 import sys
@@ -66,15 +67,14 @@ class RaceDB:
         return output
         
     def goalTimeNrm(self,index):
-        # sigmoid で標準化
+        # sigmoid で標準化．MUはハイパーパラメータ．
         # 計算式 : y = 1 / (1 + exp(x))
         # テキストではexp(-x)だが今回は値が小さい方が「良いタイム」のためexp(x)としてみた
-        # 例えば90[sec]をそのまま入れると exp(90)を計算することになり
-        # y = 0 に近づきすぎるため良くないと思うので一度最大値で割っておく
         # 最大値 = 最下位のタイム
         npGoalTime = np.array(self.goal_time[index])
-        c = np.max(npGoalTime)
-        y = 1 / (1 + np.exp(npGoalTime / c))
+        ave = np.average(npGoalTime)
+        MU = 50
+        y = 1 / (1 + np.exp(npGoalTime / MU - ave))
         # ndarray と list の違いがよくわかっていないので一応リストに変換しておく
         self.goal_time[index] = y.tolist()
 


### PR DESCRIPTION
RaceDBのgoalTimeNrm，最大値cで割るよりも，一定値μ=50みたいなものを用意して割るようにして，レースに関係なく一律で割る方がいいと思う．
最大値と最小値は外れ値の可能性があるという点と，シグモイド関数の理論的な意味づけみたいな点の2つの理由．（シグモイド関数はロジスティック関数の特殊形でオッズとかと関係があったりする）