### PR TITLE
ゴールタイムsigmoid標準化前調整

### DIFF
--- a/src/common/RaceDB.py
+++ b/src/common/RaceDB.py
@@ -72,9 +72,19 @@ class RaceDB:
         # テキストではexp(-x)だが今回は値が小さい方が「良いタイム」のためexp(x)としてみた
         # 最大値 = 最下位のタイム
         npGoalTime = np.array(self.goal_time[index])
+
         ave = np.average(npGoalTime)
         MU = 50
-        y = 1 / (1 + np.exp(npGoalTime / MU - ave))
+
+        # ゴールタイム調整方法を選択
+        METHOD = 3
+        if METHOD == 1:
+            y = 1 / (1 + np.exp(npGoalTime / ave))
+        elif METHOD == 2:
+            y = 1 / (1 + np.exp(npGoalTime / MU))
+        elif METHOD == 3:
+            y = 1 / (1 + np.exp((npGoalTime - ave) / MU))
+        
         # ndarray と list の違いがよくわかっていないので一応リストに変換しておく
         self.goal_time[index] = y.tolist()
 


### PR DESCRIPTION
- aveを引くとexp項が小さくなる。
- 結果 y = 1 となる問題があった。
- 先にaveを引いておくことで解決した。
- 他の調整案も選べるようにした。