### PR TITLE
パフォーマンス計算をDBから行うように変更

### DIFF
--- a/src/common/NetkeibaDB.py
+++ b/src/common/NetkeibaDB.py
@@ -83,3 +83,13 @@ class NetkeibaDB:
         for i in self.cur.fetchall():
             retList.append(i[0])
         return retList
+
+    def getMulCol(self, table_name, target_col_list, col_hint, data):
+        # 指定テーブルから複数の指定列を取り出したレコードを返す
+        sql = "SELECT " + ','.join(target_col_list) + " FROM " + table_name + " WHERE " + col_hint + " =?;"
+        self.cur.execute(sql, [data])
+        retList = []
+        for i in self.cur.fetchall():
+            retList.append(i)
+        return retList
+    

--- a/src/common/fix.py
+++ b/src/common/fix.py
@@ -1,5 +1,6 @@
 from dateutil.relativedelta import relativedelta
 from common.getFromDB import *
+import re
 
 def fixBirthDayList(args):
     # 標準化の前に誕生日を日数表記にしておく
@@ -93,3 +94,93 @@ def fixMarginList(args):
             time += marginDict[margin]
         retList.append(time)
     return retList
+
+def getStandardTime(distance, condition, track, location):
+    # レースコースの状態に依存する基準タイム(秒)を計算して返す
+    # performancePredictionで予測した係数・定数を下の辞書の値に入れる．
+    # loc_dictのOtherは中央競馬10か所以外の場合の値．10か所の平均値を取って作成する．
+    dis_coef = 0.066433
+    intercept = -9.6875
+    cond_dict = {'良':-0.3145, '稍':0.1566, '重':0.1802, '不':-0.0223}
+    track_dict = {'芝':-1.2514, 'ダ': 1.2514}
+    loc_dict = {'札幌':1.1699, '函館':0.3113, '福島':-0.3205, '新潟':-0.2800, '東京':-0.8914,\
+         '中山':0.2234, '中京':0.1815, '京都':-0.1556, '阪神':-0.4378, '小倉':0.1994, 'Other':0}
+    
+    std_time = dis_coef*distance + cond_dict[condition] + track_dict[track] + loc_dict[location] + intercept
+    return std_time
+
+def getPerformance(standard_time, goal_time, weight, grade):
+    # 走破タイム・斤量などを考慮し，「強さ(performance)」を計算
+    # 以下のeffectの値，計算式は適当
+    weight_effect = 1+ (55 - weight)/1000
+    grade_effect_dict = {'G1':1.14, 'G2':1.12, 'G3':1.10, 'OP':1.0, 'J.G1':1.0, 'J.G2':1.0, 'J.G3':1.0}
+    perform = (10 + standard_time - goal_time*weight_effect) * grade_effect_dict[grade]
+    return perform
+
+def fixCumPerformList(args):
+    # 各レースの結果から強さ(performance)を計算し，その最大値を記録していく
+    # (外れ値を除くために，2番目の強さでもいいかもしれない．)
+    # col = ["horse_id", "venue", "time", "burden_weight", "course_condition", "distance", "grade"]
+    HORSE_ID         = 0
+    VENUE            = 1
+    TIME             = 2
+    BURDEN_WEIGHT    = 3
+    COURSE_CONDITION = 4
+    DISTANCE         = 5
+    GRADE            = 6
+    loc_list = ['札幌', '函館', '福島', '新潟', '東京', '中山', '中京', '京都', '阪神', '小倉']
+    max_performance_list = []
+
+    for raw in args:
+        # raw = [[(馬Aレースa情報), (馬Aレースb情報), ... ], [(馬Bレースc情報), (馬Bレースd情報), ...]]
+        for race in raw:
+            for horse_info in race:
+                # horse_info = ('1982106916', '3小倉8', '1:12.7', '53', '良', '芝1200', '-1')
+                max_performance = -1000.0
+                # ゴールタイムを取得
+                goaltime = horse_info[TIME]
+                try:
+                    goaltime_sec = float(goaltime.split(':')[0])*60 + float(goaltime.split(':')[1])
+                except:
+                    goaltime_sec = 240
+                # 斤量を取得
+                try:
+                    burden_weight = float(horse_info[BURDEN_WEIGHT])
+                except:
+                    burden_weight = 40
+                # 馬場状態を取得
+                condition = horse_info[COURSE_CONDITION]
+                # 競馬場を取得
+                location = horse_info[VENUE]
+                if location not in loc_list:
+                    location = "Other"
+                # 芝かダートか
+                if horse_info[DISTANCE][0] == "芝":
+                    track = "芝"
+                elif horse_info[DISTANCE][0] == "ダ":
+                    track = "ダ"
+                else:
+                    track = "E"
+                # コースの距離
+                dis_str = horse_info[DISTANCE]
+                try:
+                    distance = float(re.sub(r'\D', '', dis_str).replace(" ", ""))
+                except:
+                    distance = "E"
+                # レースのグレード (G1,G2,G3,OP)
+                # 日本の中央競馬以外のレースは全てOP扱いになる
+                grade = horse_info[GRADE]
+                if grade == "-1":
+                    grade = "OP"
+                else:
+                    grade = "G" + grade
+                # 計算不能な場合を除いてperformanceを計算
+                if track != "E" and distance != "E":
+                    standard_time = getStandardTime(distance, condition, track, location)
+                    performance = getPerformance(standard_time, goaltime_sec, burden_weight, grade)
+
+                if performance > max_performance:
+                    max_performance = performance
+
+            max_performance_list.append(max_performance)
+    return max_performance_list

--- a/src/common/getFromDB.py
+++ b/src/common/getFromDB.py
@@ -124,3 +124,15 @@ def getRaceDateList(race_id):
     raceDateMon = int(raceDate.split("年")[1].split("月")[0])
     raceDateDay = int(raceDate.split("月")[1].split("日")[0])
     return date(raceDateYear, raceDateMon, raceDateDay)
+
+def getCumPerformList(race_id):
+    # race_id に出場した馬のリストを取得
+    # 各馬の以下情報を取得、fixでパフォーマンスを計算する
+    col = ["horse_id", "venue", "time", "burden_weight", "course_condition", "distance", "grade"]
+    horse_list = db.getRecordDataFromTbl("race_info", "race_id", race_id)
+    horse_info_list = []
+    for horse in horse_list:
+        # horse の全てのレコードを取得
+        race = db.getMulCol("race_info", col, "horse_id", horse)
+        horse_info_list.append(race)
+    return horse_info_list

--- a/src/common/normalization.py
+++ b/src/common/normalization.py
@@ -129,3 +129,7 @@ def nrmHorseNumList(hnList):
     npcdList = np.array(hnList)
     npcdList = npcdList / MAX_HORSE_NUM
     return npcdList.tolist()
+
+def nrmCumPerformList(cpList):
+    return cpList
+    

--- a/src/common/padding.py
+++ b/src/common/padding.py
@@ -91,3 +91,11 @@ def padCourseDistanceList(rowList, listSize):
 
 def padHorseNumList(rowList, listSize):
     return rowList
+
+def padCumPerformList(rowList, listSize):
+    exSize = listSize - len(rowList)
+    if exSize > 0:
+        for i in range(exSize):
+            rowList.append(0)
+    return rowList
+    


### PR DESCRIPTION
パフォーマンスを計算して学習パラメータに追加する処理をSQLite対応した。
パラメータ計算などの考案がススズなので、確認してマージしたい。
直近のmainブランチへのプッシュにより
race_infoテーブルにgrade列が追加された。
getFromDB.py/getCumPerformList()で
以下列の要素を取り出してきて計算する。
["horse_id", "venue", "time", "burden_weight", "course_condition", "distance", "grade"]
計算の流れは以下。
1. レースに出場する馬のリストを取得
2. 馬ごとにパフォーマンスを計算
2.1. 馬の出場レース一覧を取得、パフォーマンス計算、最大パフォーマンスを更新
3. 学習パラメータに各馬の最大パフォーマンス列を追加
scrapingDataNrm.pyに本処理があったときからの変更,追加点↓
- pickleのDBからではなくSQLiteDBから情報を読み込むように変更
- DB情報から判断:コースコンディションのうち以下ディクショナリ名を変更 ：'稍重'→'稍', '不良'→'不'
- レースのグレード取得失敗時の'E'代入処理→グレード1,2,3以外はDBでは-1が格納されているためそれで判断可能なため
- padで追加したダミーのパフォーマンスはゼロ