### PR TITLE
Refactoring scrape raceid

### DIFF
--- a/src/scraping/netkeiba_scraping.py
+++ b/src/scraping/netkeiba_scraping.py
@@ -75,15 +75,13 @@ def create_table():
     conn.close()
 
 
-def scrape_raceID(driver, year_month, race_grade="4"):
+def scrape_raceID(driver, start_YYMM, end_YYMM, race_grade="4"):
     """指定期間内のraceIDを取得する。
     driver: webdriver
     year_month: 取得する年月(1986年以降)の指定 <例> ["198601", "202012"] (1986年1月から2020年12月)
     race_grade: 取得するグレードのリスト 1: G1, 2: G2, 3: G3, 4: OP以上全て
     """
 
-    start_YYMM = year_month[0]
-    end_YYMM   = year_month[1]
     race_grade_name = "check_grade_{}".format(race_grade)
 
     try:
@@ -95,7 +93,9 @@ def scrape_raceID(driver, year_month, race_grade="4"):
     
     # 期間内のレースIDを取得する
     while head <= tail:
-        # head から (head+2) 月までのレースを検索
+        # head 月から (head+2) 月までのレースを検索
+        # 指定範囲を一度にスクレイピングしないのは
+        # 通信失敗時のロールバックを抑えるためと検索結果を1ページ(100件)以内に抑えるため
         ptr = head + relativedelta(months = 2)
         if ptr > tail:
             ptr = tail
@@ -597,14 +597,14 @@ def url2trainerID(url: str):
     return id
 
 
-def update_database(driver, year_month, race_grade="4"):
+def update_database(driver, start_YYMM, end_YYMM, race_grade="4"):
     """データベース全体を更新する
     driver: webdriver
     year_month: 取得する年月(1986年以降)の指定 <例> ["198601", "202012"] (1986年1月から2020年12月)
     race_grade: 取得するグレードのリスト 1: G1, 2: G2, 3: G3, 4: OP以上全て
     """
     # 期間内のrace_idを取得してrace_idテーブルへ保存
-    scrape_raceID(driver, year_month, race_grade)
+    scrape_raceID(driver, start_YYMM, end_YYMM, race_grade)
 
     # 未調査のrace_idのリストを作成
     raceID_list = make_raceID_list()
@@ -648,7 +648,7 @@ if __name__ == "__main__":
     driver = wf.start_driver(browser)
     #login(driver, mail_address, password)
 
-    #update_database(driver, ["202012","202012"])
+    #update_database(driver, "202012", "202012")
     #update_horsedata_only(driver, ["2014100492"])
 
     #a = scrape_race_today(driver, "202205040911")

--- a/src/scraping/netkeiba_scraping.py
+++ b/src/scraping/netkeiba_scraping.py
@@ -135,9 +135,7 @@ def scrape_raceID(driver, year_month, race_grade="4"):
         raceID_list = raceID_list[::-1]
         # dbのrace_idテーブルに保存
         logger.debug("saving race_id {0}.{1}-{2}.{3} on database started".format(head.year, head.month, ptr.year, ptr.month))
-        # debug
-        logger.debug("raceID_list  = {0}".format(raceID_list))
-        # netkeibaDB.sql_insert_RowToRaceId(raceID_list)
+        netkeibaDB.sql_insert_RowToRaceId(raceID_list)
         logger.info("saving race_id {0}.{1}-{2}.{3} on database completed".format(head.year, head.month, ptr.year, ptr.month))
 
         # 検索の開始年月を (ptr + 1) 月からに再設定

--- a/src/scraping/netkeiba_scraping.py
+++ b/src/scraping/netkeiba_scraping.py
@@ -76,9 +76,10 @@ def create_table():
 
 
 def scrape_raceID(driver, start_YYMM, end_YYMM, race_grade="4"):
-    """指定期間内のraceIDを取得する。
+    """start_YYMM から end_YYMM までの芝・ダートレースのraceIDを取得する
     driver: webdriver
-    year_month: 取得する年月(1986年以降)の指定 <例> ["198601", "202012"] (1986年1月から2020年12月)
+    start_YYMM: 取得開始年月(1986年以降推奨) <例> "198601" (1986年1月)
+    end_YYMM: 取得終了年月(1986年以降推奨) <例> "198601" (1986年1月)
     race_grade: 取得するグレードのリスト 1: G1, 2: G2, 3: G3, 4: OP以上全て
     """
 
@@ -600,7 +601,8 @@ def url2trainerID(url: str):
 def update_database(driver, start_YYMM, end_YYMM, race_grade="4"):
     """データベース全体を更新する
     driver: webdriver
-    year_month: 取得する年月(1986年以降)の指定 <例> ["198601", "202012"] (1986年1月から2020年12月)
+    start_YYMM: 取得開始年月(1986年以降推奨) <例> "198601" (1986年1月)
+    end_YYMM: 取得終了年月(1986年以降推奨) <例> "198601" (1986年1月)
     race_grade: 取得するグレードのリスト 1: G1, 2: G2, 3: G3, 4: OP以上全て
     """
     # 期間内のrace_idを取得してrace_idテーブルへ保存


### PR DESCRIPTION
#17 

## 日付文字列の抜き取り
この後の3か月ごとの検索が簡単になるため、YYYYMM形式でdatetimeオブジェクトを生成するように変更した。
開始年月と終了年月をリストで渡している意図はわからなかった。  
意図しない引数もアペンドできるので危険ではないか。これならstartとendで引数を2つ用意しても良いと思う。

## ループの削減  
年リスト、月リスト(4半期ごと)を作成して検索範囲を求めていたが、  
検索の開始年月から3か月刻みで検索するように変更した。
月をいくつかに分割してスクレイピングしているのは通信エラー時の情報取得失敗の被害を抑えるための措置という認識なので、この変更は問題ないと判断している。  
(「検索範囲を2020年12月～に指定していても実は2020年1月から検索する」という実際の挙動と関数機能との差異を無くした。)  

## 動作確認
- 検索条件を["202012","202012"] で実行して、DBへ登録するレースIDが従来の実行結果と一致していることを確認した。
- 検索条件を["202012","202106"]で実行して、3か月間隔で検索条件を設定できていることを確認した。