### PR TITLE
定期的なデータベース更新方法の変更

### DIFF
--- a/src/scraping/netkeiba_scraping.py
+++ b/src/scraping/netkeiba_scraping.py
@@ -714,6 +714,22 @@ def update_database_learning(driver, start_YYMM, end_YYMM, race_grade="-1"):
     tail_year = datetime.datetime.strptime(end_YYMM, '%Y%m').year
     update_jockey_info(head_year, tail_year)
 
+def update_database_stdTime(driver, start_YYMM, end_YYMM, race_grade="4"):
+    """基準タイム推定に使用する情報の取得
+    3着タイムを使用するため、race_resultテーブルを更新する
+    driver: webdriver
+    start_YYMM: 取得開始年月(1986年以降推奨) <例> "198601" (1986年1月)
+    end_YYMM: 取得終了年月(1986年以降推奨) <例> "198601" (1986年1月)
+    race_grade: 取得するグレードのリスト 1: G1, 2: G2, 3: G3, 4: OP以上全て, -1: G1&G2&G3
+    """
+    # 期間内のrace_idを取得してrace_idテーブルへ保存
+    scrape_raceID(driver, start_YYMM, end_YYMM, race_grade)
+
+    # 未調査のrace_idのリストを作成
+    raceID_list = make_raceID_list()
+
+    # レース結果をスクレイプしてrace_resultテーブルへ保存
+    a = scrape_racedata(driver, raceID_list)
 
     
 def update_jockey_info(lower_year=1980, upper_year=2021):

--- a/src/scraping/netkeiba_scraping.py
+++ b/src/scraping/netkeiba_scraping.py
@@ -619,7 +619,8 @@ def url2ID(url, search):
         return dom[dom.index(search) + 1]
     logger.critical("{0} is not found in {1}".format(search, url))
 
-def update_database(driver, start_YYMM, end_YYMM, race_grade="4"):
+
+def update_database_all(driver, start_YYMM, end_YYMM, race_grade="4"):
     """データベース全体を更新する
     driver: webdriver
     start_YYMM: 取得開始年月(1986年以降推奨) <例> "198601" (1986年1月)
@@ -652,10 +653,9 @@ def update_database(driver, start_YYMM, end_YYMM, race_grade="4"):
 
     logger.info("update_database comp")
 
-def update_horsedata_only(driver, horseID_list):
-    """レース直前にレースに出走する馬に関係する情報のみ集める
-    レースの予想に必要なのはrace_infoテーブル。
-    scrape_horsedataを実行し、race_infoとhorse_profを更新する。
+def update_database_predict(driver, horseID_list):
+    """レース直前に、レース結果の予想に必要なデータのみを集める。
+    レースに出走する馬に対して、scrape_horsedataを実行し、race_infoとhorse_profを更新する。
     driver: webdriver
     horseID_list: レースに出走する馬のhorse idのリスト
     """
@@ -735,7 +735,7 @@ if __name__ == "__main__":
         create_table()
         start = "198601"
         end = datetime.datetime.now().strftime("%Y%m")
-        update_database(driver, start, end)
+        update_database_all(driver, start, end)
 
     # 定期的なDBアップデート
     # 1ヶ月間隔更新前提
@@ -750,7 +750,7 @@ if __name__ == "__main__":
         start = start.strftime("%Y%m")
 
         logger.info("start = {0}, end = {1}".format(start, end))
-        update_database(driver, start, end)
+        update_database_all(driver, start, end)
     
     elif args.race_id:
         driver = wf.start_driver(browser)
@@ -760,7 +760,7 @@ if __name__ == "__main__":
         a = scrape_race_today(driver, args.race_id)
 
         # 出走する馬のDB情報をアップデート
-        update_horsedata_only(driver, a.horse_id)
+        update_database_predict(driver, a.horse_id)
 
         # 推測用に取得したレース情報を一時保存
         with open(path_tmp, 'wb') as f:


### PR DESCRIPTION
# 問題
update_database関数によるデータベース更新は、データベース上に存在していて、かつ引退フラグが立っていない馬を全て更新するという挙動であった。
しかし引退フラグは中央所属の馬のみで立つものであり、地方所属や外国の馬では反映されない。
結果として、学習で利用するためには更新する必要のない引退馬のページにアクセスすることになり、無駄な処理が発生していた。
特に非重賞レースのみに出走した馬などは、大量の出走履歴が存在する傾向にあり、データベースとの比較にも大きな時間が消費されていた。

# 改善点
1. 期間内の重賞レースとそれに出走した馬のデータのみをスクレイプする関数(update_database_learning)を用意し、これを利用することで学習に必要なデータをスクレイプするように変更した。
2. 今までのupdate_database関数はupdate_database_allとして残してある。