### PR TITLE
ファイルのエンコードをsjisに変更

### DIFF
--- a/predict.bat
+++ b/predict.bat
@@ -1,5 +1,7 @@
-REM å½“æ—¥ãƒ¬ãƒ¼ã‚¹ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚° + æŽ¨æ¸¬ + è³­ã‘ã‚‹
-REM !! ã“ã“ã§å­¦ç¿’ã¯è¡Œã‚ãªã„ã€‚å­¦ç¿’ã¯ prepare.bat
+CHCP 932
+
+REM “–“úƒŒ[ƒXƒXƒNƒŒƒCƒsƒ“ƒO + „‘ª + “q‚¯‚é
+REM !! ‚±‚±‚ÅŠwK‚Ís‚í‚È‚¢BŠwK‚Í prepare.bat
 
 REM scrape
 python ./src/scraping/netkeiba_scraping2.py %1 %2 %3

--- a/prepare.bat
+++ b/prepare.bat
@@ -1,3 +1,4 @@
+CHCP 932
 
 REM encoding
 python ./src/deepLearning/encoding/encodingMain.py


### PR DESCRIPTION
fixed #34 
batのファイルエンコードはutf8、PowerShellはsjis、Popenはsjisで実行していた。  
batのファイルエンコードをsjisにして、ファイル内でも明示的にsjisを使用していることを示した。